### PR TITLE
Propose fix for install issues.

### DIFF
--- a/MOCK/DESCRIPTION
+++ b/MOCK/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person("Dennis Assenmacher", "Developer",role = c("aut","cre","cph"
 	      person("Chrstian Homberg", "Developer", role = c("aut","cre","cph"),email = "c_homb01@uni-muenster.de"))
 Description: MOCK implementation based on R. Provides the mock function as well as all related functions. Also contains various visualization functions.
 License: GPL (>= 2)
-Depends: ggthemes,ggplot2
+Depends: ggthemes, ggplot2, assertthat, colorspace, gtable, scales, permute
 Imports: Rcpp (>= 0.11.6),ggplot2,ggthemes,RANN,emoa,gridExtra,nsga2R,vegan
 BugReports: https://github.com/Dennis1989/MOCK/issues
 URL: https://github.com/Dennis1989/MOCK


### PR DESCRIPTION
Proposed fix for the install issues that `MOCK` faces on new and plain R installations (problems encountered in version `3.3.1`).

Issues identified:

``` r
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'assertthat'
Error : package 'ggthemes' could not be loaded
ERROR: lazy loading failed for package 'MOCK'
* removing 'C:/Program Files/R/R-3.3.1/library/MOCK'
Error: Command failed (1)

** R
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'colorspace'
Error : package 'ggthemes' could not be loaded
ERROR: lazy loading failed for package 'MOCK'
* removing 'C:/Program Files/R/R-3.3.1/library/MOCK'
Error: Command failed (1)

** R
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'gtable'
Error : package 'ggthemes' could not be loaded
ERROR: lazy loading failed for package 'MOCK'
* removing 'C:/Program Files/R/R-3.3.1/library/MOCK'
Error: Command failed (1)

** R
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'scales'
Error : package 'ggthemes' could not be loaded
ERROR: lazy loading failed for package 'MOCK'
* removing 'C:/Program Files/R/R-3.3.1/library/MOCK'
Error: Command failed (1)

** R
** preparing package for lazy loading
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called 'permute'
ERROR: lazy loading failed for package 'MOCK'
* removing 'C:/Program Files/R/R-3.3.1/library/MOCK'
Error: Command failed (1)
```
